### PR TITLE
Add Windows support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,5 +21,8 @@ jobs:
           gh release create latest \
             --title latest \
             --notes "See README for usage: https://github.com/hiroya-uga/git-cd#readme" \
+            bin/git-cd.ps1 \
+            bin/git-cd.cmd \
+            install.ps1 \
             bin/git-cd \
             install.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,18 @@ jobs:
         run: |
           bats tests/bin/git-cd.bats
           bats tests/install.bats
+
+  pester:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Pester
+        shell: pwsh
+        run: Install-Module -Name Pester -Scope CurrentUser -Force
+
+      - name: Run Pester tests
+        shell: pwsh
+        run: |
+          Invoke-Pester -CI -Path tests/bin/git-cd.Tests.ps1, tests/install.Tests.ps1

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["USERPROFILE", "winget"]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,14 @@
 
 ## Test
 
-This project uses `bats` for `bin/git-cd`.
+This project currently uses:
+
+- `bats` for `bin/git-cd` and `install.sh`
+- `Pester` for `bin/git-cd.ps1` and `install.ps1`
 
 ## Run Tests Locally
+
+### Bash / macOS / Linux
 
 Install `bats` if needed:
 
@@ -12,10 +17,34 @@ Install `bats` if needed:
 brew install bats-core
 ```
 
-Run the tests:
+Run the bash tests:
 
 ```sh
-bats bin/__tests__/git-cd.bats
+bats tests/bin/git-cd.bats
+bats tests/install.bats
+```
+
+### PowerShell
+
+Install `Pester` from a `pwsh` session if needed.
+
+```powershell
+Install-Module -Name Pester -Scope CurrentUser
+```
+
+Run the PowerShell tests from a `pwsh` session:
+
+```powershell
+Invoke-Pester tests/bin/git-cd.Tests.ps1
+Invoke-Pester tests/install.Tests.ps1
+```
+
+Or run it without opening an interactive `pwsh` session:
+
+```sh
+pwsh -NoProfile -Command "Install-Module -Name Pester -Scope CurrentUser"
+pwsh -NoProfile -Command "Invoke-Pester tests/bin/git-cd.Tests.ps1"
+pwsh -NoProfile -Command "Invoke-Pester tests/install.Tests.ps1"
 ```
 
 ## CI
@@ -26,15 +55,48 @@ GitHub Actions runs:
 
 ## Test Parity
 
-The current scenarios covered by `bats` include:
+`bats` and `Pester` are intended to cover the same user-facing scenarios.
 
-- Help output
-- Invalid search root
-- Repository discovery from path
-- Depth limit handling
-- `node_modules` / macOS ignored directories
-- `--cache` behavior
-- Submodule inclusion and exclusion
-- Scoped searches with combined options
+The current shared scenarios are:
 
-When adding or changing a scenario, update `bin/__tests__/git-cd.bats`.
+| Scenario                                                 | Bash (`bats`) | PowerShell (`Pester`) |
+| -------------------------------------------------------- | ------------- | --------------------- |
+| Help output                                              | Yes           | Yes                   |
+| Invalid search root                                      | Yes           | Yes                   |
+| `--depth` without a value is an error                    | Yes           | Yes                   |
+| No argument → searches default root                      | Yes           | Yes                   |
+| `.` argument searches current directory                  | Yes           | Yes                   |
+| `./` / `.\` argument searches current directory          | Yes           | Yes                   |
+| `./cd` / `.\cd` argument searches subdirectory           | Yes           | Yes                   |
+| `git-cd.root` config used as default search path         | Yes           | Yes                   |
+| Repository discovery from path                           | Yes           | Yes                   |
+| Depth limit excludes deeper repos                        | Yes           | Yes                   |
+| `node_modules` directories are skipped                   | Yes           | Yes                   |
+| macOS-specific ignored directories are skipped           | Yes           | No                    |
+| Windows-specific ignored directories are skipped         | No            | Yes                   |
+| Depth limit excludes all repos                           | Yes           | Yes                   |
+| Depth limit includes deep repo when sufficient           | Yes           | Yes                   |
+| Path + `--depth` combined                                | Yes           | Yes                   |
+| `--cache` reuses the existing cache without rewriting it | Yes           | Yes                   |
+| Submodules excluded by default                           | Yes           | Yes                   |
+| Submodules included with `--submodules`                  | Yes           | Yes                   |
+| Nested submodule recursion with `--submodules`           | Yes           | Yes                   |
+| Path + `--submodules` + `--depth` combined               | Yes           | Yes                   |
+| Search stays inside the specified subtree                | Yes           | Yes                   |
+
+Some assertion details are allowed to differ between the two test suites:
+
+- Repository enumeration order may differ between bash and PowerShell implementations.
+- Platform-specific ignored directories differ by implementation (`Library` / `.Trash` on bash, `AppData` / `$RECYCLE.BIN` / `System Volume Information` on PowerShell).
+- When order is not stable, the PowerShell tests may assert that the result is one of the valid candidates instead of a single fixed path.
+- Path formatting and stderr handling may differ slightly by shell/runtime, but the user-facing behavior should stay equivalent.
+
+When adding or changing a scenario, update both:
+
+- `tests/bin/git-cd.bats`
+- `tests/bin/git-cd.Tests.ps1`
+
+When adding or changing an install scenario, update both:
+
+- `tests/install.bats`
+- `tests/install.Tests.ps1`

--- a/README-WIN.md
+++ b/README-WIN.md
@@ -1,0 +1,99 @@
+# git-cd for Windows
+
+Navigate to git repositories interactively from PowerShell.
+
+> `git-cd.cmd` is the launcher shim for Windows, but persistent `cd` behavior is provided in PowerShell via the profile function installed by `install.ps1`. Plain `cmd.exe` can invoke the helper, but it cannot change the parent shell's current directory after the process exits.
+
+## Usage
+
+```powershell
+git cd
+```
+
+Searches for git repositories under `$env:USERPROFILE` and displays them in an interactive list. Select one to move to that directory.
+
+If [fzf](https://github.com/junegunn/fzf) is installed, it will be used for fuzzy selection. Otherwise, a numbered list is displayed.
+
+### Arguments
+
+```powershell
+git cd [path]
+```
+
+Specify a starting directory to search from. Defaults to `$env:USERPROFILE`.
+
+### Options
+
+| Option         | Description                                              |
+| -------------- | -------------------------------------------------------- |
+| `--depth <n>`  | Limit directory traversal depth (default: 5)             |
+| `--submodules` | Include git submodules in the list (excluded by default) |
+| `--cache`      | Use cached results for faster startup                    |
+| `-h, --help`   | Show this help message                                   |
+
+## Caching
+
+By default, repositories are searched fresh on every run and the latest result is written to the cache file. Pass `--cache` to reuse the current cached list as-is.
+
+The cache is stored at `%LOCALAPPDATA%\git-cd\cache`.
+
+## Installation
+
+### Quick install
+
+```powershell
+Invoke-RestMethod https://github.com/hiroya-uga/git-cd/releases/latest/download/install.ps1 | Invoke-Expression
+```
+
+### Clone (easier to update later)
+
+```powershell
+git clone https://github.com/hiroya-uga/git-cd.git "$env:USERPROFILE\.git-cd"
+& "$env:USERPROFILE\.git-cd\install.ps1"
+```
+
+To update:
+
+```powershell
+git -C "$env:USERPROFILE\.git-cd" pull
+& "$env:USERPROFILE\.git-cd\install.ps1"
+```
+
+### What `install.ps1` does
+
+1. Places `git-cd.ps1` and `git-cd.cmd` at `$env:USERPROFILE\bin\` and adds `$env:USERPROFILE\bin` to `PATH` if needed
+    - Clone install: copies the script files (re-run `install.ps1` after `git pull` to apply updates)
+    - Quick install: downloads the scripts directly from GitHub Releases
+    - `git-cd.cmd` is the command shim that launches the PowerShell helper script
+2. Appends a shell function to `$PROFILE` (creating the profile directory/file if needed)
+    - `git cd` is handled by this function so that `cd` runs in the current shell process — without it, directory changes would not persist after the command exits
+
+Open a new terminal and you're ready to go.
+
+## Uninstall
+
+### Quick install
+
+```powershell
+Remove-Item "$env:USERPROFILE\bin\git-cd.ps1"
+Remove-Item "$env:USERPROFILE\bin\git-cd.cmd"
+```
+
+Then remove the shell function from `$PROFILE` — delete the lines between `# git-cd BEGIN` and `# git-cd END`.
+
+If `$env:USERPROFILE\bin` was added to `PATH` by the installer, you can remove it via **System Properties → Environment Variables → User variables → Path**.
+
+### Clone install
+
+```powershell
+Remove-Item "$env:USERPROFILE\bin\git-cd.ps1"
+Remove-Item "$env:USERPROFILE\bin\git-cd.cmd"
+Remove-Item -Recurse "$env:USERPROFILE\.git-cd"  # adjust this path if you cloned to a different location
+```
+
+Then remove the shell function from `$PROFILE` — delete the lines between `# git-cd BEGIN` and `# git-cd END`.
+
+## Requirements
+
+- PowerShell 5.1 or later
+- [fzf](https://github.com/junegunn/fzf) (optional, recommended — install with `winget install fzf`)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Navigate to git repositories interactively from the command line.
 
+> For Windows PowerShell, see [README-WIN.md](README-WIN.md).
+
 ## Usage
 
 ```sh

--- a/bin/git-cd.cmd
+++ b/bin/git-cd.cmd
@@ -1,0 +1,10 @@
+@echo off
+
+where pwsh.exe >nul 2>nul
+if not errorlevel 1 (
+  pwsh.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0git-cd.ps1" %*
+  exit /b %errorlevel%
+)
+
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0git-cd.ps1" %*
+exit /b %errorlevel%

--- a/bin/git-cd.ps1
+++ b/bin/git-cd.ps1
@@ -1,0 +1,128 @@
+$Depth = 5
+$Submodules = $false
+$Cache = $false
+$CacheFile = Join-Path $env:LOCALAPPDATA "git-cd\cache"
+
+function Write-Stderr {
+    param([string]$Message)
+
+    [Console]::Error.WriteLine($Message)
+}
+
+function Exit-WithError {
+    param([string]$Message)
+
+    Write-Stderr $Message
+    exit 1
+}
+
+if (-not $env:USERPROFILE) {
+    Exit-WithError "USERPROFILE environment variable is not set"
+}
+
+$configuredRoot = & git config --global --get git-cd.root 2>$null
+$SearchPath = if ($configuredRoot) { $configuredRoot } else { $env:USERPROFILE }
+
+function Show-Usage {
+    Write-Host "Usage: git cd [path] [options]"
+    Write-Host ""
+    Write-Host "Navigate to a git repository interactively."
+    Write-Host ""
+    Write-Host "Options:"
+    Write-Host "  --depth <n>     Limit directory traversal depth (default: 5)"
+    Write-Host "  --submodules    Include git submodules in the list"
+    Write-Host "  --cache         Use cached results for faster startup"
+    Write-Host "  -h, --help      Show this help"
+    Write-Host ""
+    Write-Host "Configuration:"
+    Write-Host "  git config --global git-cd.root <path>"
+    Write-Host "                  Set the default search directory (overrides `$env:USERPROFILE)"
+}
+
+# Parse arguments manually to match --flag style used on macOS
+$i = 0
+while ($i -lt $args.Count) {
+    switch ($args[$i]) {
+        ''             { break }
+        '--depth' {
+            if ($i + 1 -ge $args.Count) { Exit-WithError "--depth requires a value" }
+            $Depth = [int]$args[++$i]
+            break
+        }
+        '--submodules' { $Submodules = $true; break }
+        '--cache'      { $Cache = $true; break }
+        '--help'       { Show-Usage; exit 0 }
+        '-h'           { Show-Usage; exit 0 }
+        default {
+            if ($args[$i] -notlike '--*') { $SearchPath = $args[$i] }
+            else { Exit-WithError "Unknown option: $($args[$i])" }
+        }
+    }
+    $i++
+}
+
+# When the profile's git wrapper forwards 'cd' as a positional arg and it's not a real
+# directory, treat it as the subcommand name (not a path) and fall back to the default root.
+if ($SearchPath -eq 'cd' -and -not (Test-Path $SearchPath -PathType Container -ErrorAction SilentlyContinue)) {
+    $SearchPath = if ($configuredRoot) { $configuredRoot } else { $env:USERPROFILE }
+}
+
+if (-not (Test-Path $SearchPath -PathType Container -ErrorAction SilentlyContinue)) {
+    Exit-WithError "Not a directory: $SearchPath"
+}
+$SearchPath = (Resolve-Path $SearchPath).Path
+
+$SkipDirs = @('node_modules', '.git', 'AppData', '$RECYCLE.BIN', 'System Volume Information')
+
+$SearchBlock = {
+    param([string]$Root, [int]$MaxDepth, [bool]$IncludeSubmodules, [string[]]$Skip)
+
+    function Search([string]$Path, [int]$Depth) {
+        $gitPath = Join-Path $Path '.git'
+        $isRepo = Test-Path $gitPath -ErrorAction SilentlyContinue
+        $isDir  = $isRepo -and (Test-Path $gitPath -PathType Container -ErrorAction SilentlyContinue)
+
+        if ($isRepo -and ($IncludeSubmodules -or $isDir)) {
+            $Path
+        }
+
+        if ($Depth -ge $MaxDepth) { return }
+
+        Get-ChildItem -Path $Path -Directory -Force -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -notin $Skip } |
+            ForEach-Object { Search $_.FullName ($Depth + 1) }
+    }
+
+    Search $Root 0
+}
+
+function Find-Repos {
+    & $SearchBlock $SearchPath $Depth $Submodules $SkipDirs
+}
+
+# Get repo list
+if ($Cache -and (Test-Path $CacheFile)) {
+    $repos = Get-Content $CacheFile
+} else {
+    $repos = Find-Repos
+    New-Item -ItemType Directory -Force -Path (Split-Path $CacheFile) | Out-Null
+    $repos | Set-Content $CacheFile
+}
+
+if (-not $repos) {
+    Exit-WithError "No git repositories found under $SearchPath"
+}
+
+# Select
+if (Get-Command fzf -ErrorAction SilentlyContinue) {
+    $selected = $repos | fzf
+} else {
+    $i = 1
+    $repos | ForEach-Object { Write-Host "$i) $_"; $i++ }
+    $num = Read-Host "Select a number"
+    $selected = $repos | Select-Object -Index ([int]$num - 1)
+}
+
+if (-not $selected) { exit 1 }
+
+Write-Output $selected

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,78 @@
+$ErrorActionPreference = 'Stop'
+
+$InstallDir = Join-Path $env:USERPROFILE "bin"
+$ScriptDir = if ($PSScriptRoot) {
+    $PSScriptRoot
+} elseif ($MyInvocation.MyCommand.Path) {
+    Split-Path -Parent $MyInvocation.MyCommand.Path
+} else {
+    $null
+}
+$HasLocalScripts = $ScriptDir -and
+    (Test-Path (Join-Path $ScriptDir "bin\git-cd.ps1")) -and
+    (Test-Path (Join-Path $ScriptDir "bin\git-cd.cmd"))
+
+$ShellFunction = @'
+
+# git-cd BEGIN
+function git {
+    if ($args[0] -eq 'cd') {
+        $rest = @(if ($args.Length -gt 1) { $args[1..($args.Length - 1)] } else { @() })
+        $dir = & git-cd @rest
+        if ($dir) { Set-Location $dir }
+    } else {
+        & (Get-Command git -CommandType Application) @args
+    }
+}
+# git-cd END
+'@
+
+# Place git-cd.ps1
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+
+if ($HasLocalScripts) {
+    # Clone install: copy scripts
+    Copy-Item (Join-Path $ScriptDir "bin\git-cd.ps1") (Join-Path $InstallDir "git-cd.ps1") -Force
+    Copy-Item (Join-Path $ScriptDir "bin\git-cd.cmd") (Join-Path $InstallDir "git-cd.cmd") -Force
+    Write-Host "Copied: $InstallDir\git-cd.ps1"
+    Write-Host "Copied: $InstallDir\git-cd.cmd"
+} else {
+    # Quick install: download from GitHub Releases
+    Invoke-WebRequest -Uri "https://github.com/hiroya-uga/git-cd/releases/latest/download/git-cd.ps1" `
+        -OutFile (Join-Path $InstallDir "git-cd.ps1")
+    Invoke-WebRequest -Uri "https://github.com/hiroya-uga/git-cd/releases/latest/download/git-cd.cmd" `
+        -OutFile (Join-Path $InstallDir "git-cd.cmd")
+    Write-Host "Downloaded: $InstallDir\git-cd.ps1"
+    Write-Host "Downloaded: $InstallDir\git-cd.cmd"
+}
+
+# Add InstallDir to PATH if not present
+$userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+if ($userPath -notlike "*$InstallDir*") {
+    $newUserPath = if ([string]::IsNullOrWhiteSpace($userPath)) { $InstallDir } else { "$userPath;$InstallDir" }
+    [Environment]::SetEnvironmentVariable("PATH", $newUserPath, "User")
+    Write-Host "Added $InstallDir to PATH"
+}
+
+# Append shell function to PowerShell profile if not already present
+New-Item -ItemType Directory -Force -Path (Split-Path -Parent $PROFILE) | Out-Null
+if (-not (Test-Path $PROFILE)) {
+    New-Item -ItemType File -Force -Path $PROFILE | Out-Null
+}
+
+$profileContent = [string](Get-Content $PROFILE -Raw)
+if ($profileContent -notlike "*# git-cd BEGIN*") {
+    Add-Content $PROFILE $ShellFunction
+    Write-Host "Added shell function to $PROFILE"
+} else {
+    $updated = [regex]::Replace($profileContent, '(?s)# git-cd BEGIN.*?# git-cd END', $ShellFunction.Trim())
+    Set-Content $PROFILE $updated -NoNewline
+    Write-Host "Updated shell function in $PROFILE"
+}
+
+Write-Host ""
+Write-Host "✅ Done!"
+Write-Host "Open a new terminal to start using 'git cd'."
+Write-Host ""
+Write-Host "Tip: install fzf for a better experience:"
+Write-Host "     winget install fzf"

--- a/tests/bin/git-cd.Tests.ps1
+++ b/tests/bin/git-cd.Tests.ps1
@@ -1,0 +1,431 @@
+$ErrorActionPreference = 'Stop'
+
+Describe 'git-cd.ps1' {
+    BeforeAll {
+        $script:RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+        $script:ScriptUnderTest = Join-Path $script:RepoRoot 'bin/git-cd.ps1'
+
+        function New-TestFixture {
+            $testRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("git-cd-pester-" + [guid]::NewGuid().ToString('N'))
+            New-Item -ItemType Directory -Force -Path $testRoot | Out-Null
+            if (-not $IsWindows) { $testRoot = (& realpath $testRoot) }
+
+            $mockBin = Join-Path $testRoot 'mock-bin'
+            New-Item -ItemType Directory -Force -Path $mockBin | Out-Null
+
+            @'
+#!/usr/bin/env bash
+input=$(cat)
+if [ -n "${FZF_CAPTURE:-}" ]; then
+  printf '%s\n' "$input" > "$FZF_CAPTURE"
+fi
+printf '%s\n' "$input" | head -n 1
+'@ | Set-Content -Path (Join-Path $mockBin 'fzf') -NoNewline
+            if (-not $IsWindows) {
+                & chmod +x (Join-Path $mockBin 'fzf')
+            }
+
+            @'
+$lines = @($input)
+if ($env:FZF_CAPTURE) {
+    $lines | Set-Content -Path $env:FZF_CAPTURE
+}
+$lines | Select-Object -First 1
+'@ | Set-Content -Path (Join-Path $mockBin 'fzf.ps1') -NoNewline
+            @'
+@echo off
+pwsh -NoProfile -File "%~dp0fzf.ps1"
+'@ | Set-Content -Path (Join-Path $mockBin 'fzf.cmd') -NoNewline
+
+            New-Item -ItemType Directory -Force -Path (Join-Path $testRoot 'windows-home') | Out-Null
+            New-Item -ItemType Directory -Force -Path (Join-Path $testRoot 'windows-localappdata') | Out-Null
+
+            return $testRoot
+        }
+
+        function Remove-TestFixture {
+            param([string]$TestRoot)
+
+            if ($TestRoot -and (Test-Path $TestRoot)) {
+                Remove-Item -Recurse -Force $TestRoot
+            }
+        }
+
+        function New-RepoFixture {
+            param([string]$TestRoot)
+
+            $root = Join-Path $TestRoot 'repos'
+
+            New-Item -ItemType Directory -Force -Path (Join-Path $root 'repo1/.git') | Out-Null
+            New-Item -ItemType Directory -Force -Path (Join-Path $root 'projects/repo2/.git') | Out-Null
+            New-Item -ItemType Directory -Force -Path (Join-Path $root 'a/b/repo3/.git') | Out-Null
+            New-Item -ItemType Directory -Force -Path (Join-Path $root 'a/b/c/d/deep-repo/.git') | Out-Null
+            New-Item -ItemType Directory -Force -Path (Join-Path $root 'parent/.git') | Out-Null
+            New-Item -ItemType Directory -Force -Path (Join-Path $root 'parent/sub') | Out-Null
+            'gitdir: ../.git/modules/sub' | Set-Content -Path (Join-Path $root 'parent/sub/.git') -NoNewline
+            New-Item -ItemType Directory -Force -Path (Join-Path $root 'parent/components/vendor') | Out-Null
+            'gitdir: ../.git/modules/vendor' | Set-Content -Path (Join-Path $root 'parent/components/vendor/.git') -NoNewline
+            New-Item -ItemType Directory -Force -Path (Join-Path $root 'repo1/node_modules/evil/.git') | Out-Null
+            New-Item -ItemType Directory -Force -Path (Join-Path $root 'AppData/hidden-repo/.git') | Out-Null
+            New-Item -ItemType Directory -Force -Path (Join-Path $root '$RECYCLE.BIN/hidden-repo/.git') | Out-Null
+            New-Item -ItemType Directory -Force -Path (Join-Path $root 'System Volume Information/hidden-repo/.git') | Out-Null
+
+            return $root
+        }
+
+        function Invoke-GitCdPs1 {
+            param(
+                [string]$TestRoot,
+                [string[]]$Arguments,
+                [string]$WorkingDirectory = $script:RepoRoot,
+                [hashtable]$ExtraEnv = @{}
+            )
+
+            $stdoutFile = Join-Path $TestRoot 'stdout.txt'
+            $stderrFile = Join-Path $TestRoot 'stderr.txt'
+            $originalPath = $env:PATH
+            $originalUserProfile = $env:USERPROFILE
+            $originalLocalAppData = $env:LOCALAPPDATA
+            $originalFzfCapture = $env:FZF_CAPTURE
+            $fzfCapture = Join-Path $TestRoot 'fzf-input.txt'
+            $env:USERPROFILE = Join-Path $TestRoot 'windows-home'
+            $env:LOCALAPPDATA = Join-Path $TestRoot 'windows-localappdata'
+            $env:FZF_CAPTURE = $fzfCapture
+            $env:PATH = "{0}{1}{2}" -f (Join-Path $TestRoot 'mock-bin'), [System.IO.Path]::PathSeparator, $env:PATH
+
+            $savedExtraEnv = @{}
+            foreach ($key in $ExtraEnv.Keys) {
+                $savedExtraEnv[$key] = [Environment]::GetEnvironmentVariable($key)
+                [Environment]::SetEnvironmentVariable($key, $ExtraEnv[$key])
+            }
+
+            try {
+                $pwshCommand = (Get-Command pwsh).Source
+                $argumentList = @('-NoProfile', '-File', $script:ScriptUnderTest) + $Arguments
+                $process = Start-Process -FilePath $pwshCommand `
+                    -ArgumentList $argumentList `
+                    -WorkingDirectory $WorkingDirectory `
+                    -RedirectStandardOutput $stdoutFile `
+                    -RedirectStandardError $stderrFile `
+                    -NoNewWindow `
+                    -PassThru `
+                    -Wait
+            } finally {
+                $env:PATH = $originalPath
+                if ($null -eq $originalUserProfile) { Remove-Item Env:USERPROFILE -ErrorAction SilentlyContinue } else { $env:USERPROFILE = $originalUserProfile }
+                if ($null -eq $originalLocalAppData) { Remove-Item Env:LOCALAPPDATA -ErrorAction SilentlyContinue } else { $env:LOCALAPPDATA = $originalLocalAppData }
+                if ($null -eq $originalFzfCapture) { Remove-Item Env:FZF_CAPTURE -ErrorAction SilentlyContinue } else { $env:FZF_CAPTURE = $originalFzfCapture }
+                foreach ($key in $savedExtraEnv.Keys) {
+                    [Environment]::SetEnvironmentVariable($key, $savedExtraEnv[$key])
+                }
+            }
+
+            $stderrRaw = if (Test-Path $stderrFile) { Get-Content -Raw $stderrFile } else { '' }
+            $stdoutRaw = if (Test-Path $stdoutFile) { Get-Content -Raw $stdoutFile } else { '' }
+            $candidateList = if (Test-Path $fzfCapture) { @(Get-Content $fzfCapture) } else { @() }
+
+            [pscustomobject]@{
+                Status = $process.ExitCode
+                Stdout = if ($stdoutRaw) { $stdoutRaw.TrimEnd() } else { '' }
+                Stderr = if ($stderrRaw) { $stderrRaw.TrimEnd() } else { '' }
+                CandidateList = $candidateList
+            }
+        }
+
+    }
+
+    BeforeEach {
+        $TestRoot = New-TestFixture
+    }
+
+    AfterEach {
+        Remove-TestFixture $TestRoot
+    }
+
+    Context 'help and validation' {
+        It 'returns usage text for --help' {
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -Arguments @('--help')
+
+            $result.Status | Should -Be 0
+            $result.Stdout | Should -Match 'Usage: git cd \[path\] \[options\]'
+        }
+
+        It 'returns an error when the search root does not exist' {
+            $missingPath = Join-Path $TestRoot 'does-not-exist'
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -Arguments @($missingPath)
+
+            $result.Status | Should -Be 1
+            $result.Stderr | Should -Match ([regex]::Escape("Not a directory: $missingPath"))
+        }
+
+        It 'returns an error when --depth is given without a value' {
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -Arguments @('--depth')
+
+            $result.Status | Should -Be 1
+            $result.Stderr | Should -Match '--depth requires a value'
+        }
+
+        It 'treats a literal cd argument as a real path' {
+            $literalRoot = Join-Path $TestRoot 'literal-cd'
+            New-Item -ItemType Directory -Force -Path (Join-Path $literalRoot 'cd/.git') | Out-Null
+
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -WorkingDirectory $literalRoot -Arguments @('cd')
+
+            $result.Status | Should -Be 0
+            $result.Stdout | Should -Match ([regex]::Escape([IO.Path]::DirectorySeparatorChar + 'literal-cd' + [IO.Path]::DirectorySeparatorChar + 'cd') + '$')
+        }
+    }
+
+    Context 'repository discovery' {
+        It 'returns one of the discovered repositories from the provided path' {
+            $root = New-RepoFixture -TestRoot $TestRoot
+            $expected = @(
+                (Join-Path $root 'repo1'),
+                (Join-Path $root 'projects/repo2'),
+                (Join-Path $root 'a/b/repo3'),
+                (Join-Path $root 'parent'),
+                (Join-Path $root 'a/b/c/d/deep-repo')
+            )
+
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -Arguments @($root)
+
+            $result.Status | Should -Be 0
+            $result.Stdout | Should -BeIn $expected
+        }
+
+        It 'excludes deeper repositories when --depth is smaller' {
+            $root = New-RepoFixture -TestRoot $TestRoot
+            $shallowRepos = @(
+                (Join-Path $root 'repo1'),
+                (Join-Path $root 'projects/repo2'),
+                (Join-Path $root 'a/b/repo3'),
+                (Join-Path $root 'parent')
+            )
+
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -Arguments @($root, '--depth', '3')
+
+            $result.Status | Should -Be 0
+            $result.Stdout | Should -BeIn $shallowRepos
+            $result.CandidateList | Should -Contain (Join-Path $root 'repo1')
+            $result.CandidateList | Should -Contain (Join-Path $root 'projects/repo2')
+            $result.CandidateList | Should -Contain (Join-Path $root 'a/b/repo3')
+            $result.CandidateList | Should -Not -Contain (Join-Path $root 'a/b/c/d/deep-repo')
+        }
+
+        It 'skips node_modules directories during discovery' {
+            $root = New-RepoFixture -TestRoot $TestRoot
+
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -Arguments @($root)
+
+            $result.Status | Should -Be 0
+            $result.CandidateList | Should -Not -Contain (Join-Path $root 'repo1/node_modules/evil')
+        }
+
+        It 'skips Windows-specific ignored directories during discovery' {
+            $root = New-RepoFixture -TestRoot $TestRoot
+
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -Arguments @($root)
+
+            $result.Status | Should -Be 0
+            $result.CandidateList | Should -Not -Contain (Join-Path $root 'AppData/hidden-repo')
+            $result.CandidateList | Should -Not -Contain (Join-Path $root '$RECYCLE.BIN/hidden-repo')
+            $result.CandidateList | Should -Not -Contain (Join-Path $root 'System Volume Information/hidden-repo')
+        }
+
+        It 'returns an error when depth excludes all repositories' {
+            $deepOnly = Join-Path $TestRoot 'deep-only'
+            New-Item -ItemType Directory -Force -Path (Join-Path $deepOnly 'a/b/c/repo/.git') | Out-Null
+
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -Arguments @($deepOnly, '--depth', '2')
+
+            $result.Status | Should -Be 1
+            $result.Stderr | Should -Match 'No git repositories found under'
+        }
+
+        It 'finds the deep repository when depth is sufficient' {
+            $deepOnly = Join-Path $TestRoot 'deep-only'
+            New-Item -ItemType Directory -Force -Path (Join-Path $deepOnly 'a/b/c/repo/.git') | Out-Null
+
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -Arguments @($deepOnly, '--depth', '4')
+
+            $result.Status | Should -Be 0
+            $result.Stdout | Should -Be (Join-Path $deepOnly 'a/b/c/repo')
+        }
+
+        It 'limits discovery when path and --depth are combined' {
+            $root = New-RepoFixture -TestRoot $TestRoot
+
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -Arguments @((Join-Path $root 'a'), '--depth', '2')
+
+            $result.Status | Should -Be 0
+            $result.CandidateList | Should -Contain (Join-Path $root 'a/b/repo3')
+            $result.CandidateList | Should -Not -Contain (Join-Path $root 'a/b/c/d/deep-repo')
+            $result.Stdout | Should -Be (Join-Path $root 'a/b/repo3')
+        }
+
+        It 'reuses the existing cache without rewriting it when --cache is enabled' {
+            $cacheRoot = Join-Path $TestRoot 'cache-root'
+            $freshRepo = Join-Path $cacheRoot 'live-repo'
+            $staleRepo = Join-Path $TestRoot 'stale-repo'
+            $cacheFile = Join-Path (Join-Path $TestRoot 'windows-localappdata') 'git-cd\cache'
+            $cacheDir = Split-Path $cacheFile -Parent
+
+            New-Item -ItemType Directory -Force -Path (Join-Path $freshRepo '.git') | Out-Null
+            New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
+            $staleRepo | Set-Content -Path $cacheFile
+
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -Arguments @($cacheRoot, '--cache')
+            $cacheContents = @(Get-Content $cacheFile)
+
+            $result.Status | Should -Be 0
+            $result.Stdout | Should -Be $staleRepo
+            $cacheContents | Should -Contain $staleRepo
+            $cacheContents | Should -Not -Contain $freshRepo
+        }
+    }
+
+    Context 'submodule handling' {
+        It 'excludes submodules by default' {
+            $submoduleOnly = Join-Path $TestRoot 'submodule-only'
+            New-Item -ItemType Directory -Force -Path (Join-Path $submoduleOnly 'sub') | Out-Null
+            'gitdir: ../.git/modules/sub' | Set-Content -Path (Join-Path $submoduleOnly 'sub/.git') -NoNewline
+
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -Arguments @($submoduleOnly)
+
+            $result.Status | Should -Be 1
+            $result.Stderr | Should -Match 'No git repositories found under'
+        }
+
+        It 'includes submodules when --submodules is enabled' {
+            $submoduleOnly = Join-Path $TestRoot 'submodule-only'
+            New-Item -ItemType Directory -Force -Path (Join-Path $submoduleOnly 'sub') | Out-Null
+            'gitdir: ../.git/modules/sub' | Set-Content -Path (Join-Path $submoduleOnly 'sub/.git') -NoNewline
+
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -Arguments @($submoduleOnly, '--submodules')
+
+            $result.Status | Should -Be 0
+            $result.Stdout | Should -Be (Join-Path $submoduleOnly 'sub')
+        }
+
+        It 'recurses into repositories to find nested submodules when --submodules is enabled' {
+            $deepParent = Join-Path $TestRoot 'deep-parent'
+            New-Item -ItemType Directory -Force -Path (Join-Path $deepParent '.git') | Out-Null
+            New-Item -ItemType Directory -Force -Path (Join-Path $deepParent 'a/b/sub') | Out-Null
+            'gitdir: ../.git/modules/sub' | Set-Content -Path (Join-Path $deepParent 'a/b/sub/.git') -NoNewline
+            $expected = @(
+                $deepParent,
+                (Join-Path $deepParent 'a/b/sub')
+            )
+
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -Arguments @($TestRoot, '--submodules')
+
+            $result.Status | Should -Be 0
+            $result.Stdout | Should -BeIn $expected
+            $result.Stdout | Should -Not -Match 'node_modules'
+        }
+
+        It 'limits discovery when path, --submodules, and --depth are combined' {
+            $scopedRoot = Join-Path $TestRoot 'scoped-submodules'
+            New-Item -ItemType Directory -Force -Path (Join-Path $scopedRoot 'parent/.git') | Out-Null
+            New-Item -ItemType Directory -Force -Path (Join-Path $scopedRoot 'parent/sub') | Out-Null
+            'gitdir: ../.git/modules/sub' | Set-Content -Path (Join-Path $scopedRoot 'parent/sub/.git') -NoNewline
+            New-Item -ItemType Directory -Force -Path (Join-Path $scopedRoot 'parent/components/vendor') | Out-Null
+            'gitdir: ../.git/modules/vendor' | Set-Content -Path (Join-Path $scopedRoot 'parent/components/vendor/.git') -NoNewline
+            $expected = @(
+                (Join-Path $scopedRoot 'parent'),
+                (Join-Path $scopedRoot 'parent/sub'),
+                (Join-Path $scopedRoot 'parent/components/vendor')
+            )
+
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -Arguments @($scopedRoot, '--submodules', '--depth', '3')
+
+            $result.Status | Should -Be 0
+            $result.CandidateList | Should -Contain (Join-Path $scopedRoot 'parent')
+            $result.CandidateList | Should -Contain (Join-Path $scopedRoot 'parent/sub')
+            $result.CandidateList | Should -Contain (Join-Path $scopedRoot 'parent/components/vendor')
+            $result.Stdout | Should -BeIn $expected
+        }
+    }
+
+    Context 'default search root' {
+        It 'searches USERPROFILE when no path argument is given' {
+            $homeDir = Join-Path $TestRoot 'windows-home'
+            New-Item -ItemType Directory -Force -Path (Join-Path $homeDir 'myrepo/.git') | Out-Null
+
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -Arguments @()
+
+            $result.Status | Should -Be 0
+            $result.Stdout | Should -Be (Join-Path $homeDir 'myrepo')
+        }
+
+        It 'uses git-cd.root as default search path when configured' {
+            $configuredRoot = Join-Path $TestRoot 'configured-root'
+            New-Item -ItemType Directory -Force -Path (Join-Path $configuredRoot 'myrepo/.git') | Out-Null
+            $configFile = Join-Path $TestRoot 'gitconfig'
+            $configuredRootForGit = $configuredRoot -replace '\\', '/'
+            "[git-cd]`n`troot = $configuredRootForGit" | Set-Content $configFile
+
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -Arguments @() -ExtraEnv @{ GIT_CONFIG_GLOBAL = $configFile }
+
+            $result.Status | Should -Be 0
+            $result.Stdout | Should -Be (Join-Path $configuredRoot 'myrepo')
+        }
+    }
+
+    Context 'search root argument forms' {
+        It 'searches the current directory when . is given' {
+            $dir = Join-Path $TestRoot 'dot-scope'
+            New-Item -ItemType Directory -Force -Path (Join-Path $dir 'myrepo/.git') | Out-Null
+
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -Arguments @('.') -WorkingDirectory $dir
+
+            $result.Status | Should -Be 0
+            $result.Stdout | Should -Be (Join-Path $dir 'myrepo')
+        }
+
+        It 'searches the current directory when .\ is given' {
+            $dir = Join-Path $TestRoot 'dotslash-scope'
+            New-Item -ItemType Directory -Force -Path (Join-Path $dir 'myrepo/.git') | Out-Null
+
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -Arguments @('.\') -WorkingDirectory $dir
+
+            $result.Status | Should -Be 0
+            $result.Stdout | Should -Be (Join-Path $dir 'myrepo')
+        }
+
+        It 'ignores forwarded git subcommand cd when no explicit path is given' {
+            $homeDir = Join-Path $TestRoot 'windows-home'
+            New-Item -ItemType Directory -Force -Path (Join-Path $homeDir 'myrepo/.git') | Out-Null
+
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -Arguments @('cd')
+
+            $result.Status | Should -Be 0
+            $result.Stdout | Should -Be (Join-Path $homeDir 'myrepo')
+        }
+
+        It 'searches .\cd when .\cd path is given' {
+            $dir = Join-Path $TestRoot 'dotslash-cd-scope'
+            New-Item -ItemType Directory -Force -Path (Join-Path $dir 'cd/myrepo/.git') | Out-Null
+
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -Arguments @('.\cd') -WorkingDirectory $dir
+
+            $result.Status | Should -Be 0
+            $result.Stdout | Should -Be (Join-Path $dir 'cd/myrepo')
+        }
+    }
+
+    Context 'scoped search roots' {
+        It 'limits discovery to the specified subtree' {
+            $root = New-RepoFixture -TestRoot $TestRoot
+            $expected = @(
+                (Join-Path $root 'a/b/repo3'),
+                (Join-Path $root 'a/b/c/d/deep-repo')
+            )
+
+            $result = Invoke-GitCdPs1 -TestRoot $TestRoot -Arguments @((Join-Path $root 'a'))
+
+            $result.Status | Should -Be 0
+            $result.Stdout | Should -BeIn $expected
+        }
+    }
+}

--- a/tests/install.Tests.ps1
+++ b/tests/install.Tests.ps1
@@ -1,0 +1,206 @@
+$ErrorActionPreference = 'Stop'
+
+Describe 'install.ps1' {
+    BeforeAll {
+        $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+        $script:InstallScript = Join-Path $script:RepoRoot 'install.ps1'
+
+        function New-TestFixture {
+            $testRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("install-pester-" + [guid]::NewGuid().ToString('N'))
+            New-Item -ItemType Directory -Force -Path (Join-Path $testRoot 'home') | Out-Null
+            return $testRoot
+        }
+
+        function Remove-TestFixture {
+            param([string]$TestRoot)
+            if ($TestRoot -and (Test-Path $TestRoot)) {
+                Remove-Item -Recurse -Force $TestRoot
+            }
+        }
+
+        function Invoke-InstallPs1 {
+            param(
+                [string]$TestRoot,
+                [bool]$HasLocalBin = $true,
+                [bool]$MockWebRequest = $false,
+                [string]$ExistingProfileContent = $null
+            )
+
+            $testHome    = Join-Path $TestRoot 'home'
+            $profilePath = Join-Path $TestRoot 'ps-profile.ps1'
+            $stdoutFile  = Join-Path $TestRoot 'stdout.txt'
+            $stderrFile  = Join-Path $TestRoot 'stderr.txt'
+
+            if ($null -ne $ExistingProfileContent) {
+                $ExistingProfileContent | Set-Content $profilePath -NoNewline
+            }
+
+            # Determine which install.ps1 to call.
+            # Clone path: call the repo's install.ps1 directly — the repo root has bin\,
+            # so git-cd.ps1 and git-cd.cmd will be found by install.ps1.
+            # Quick path: copy install.ps1 to a temp dir without bin\ so the download branch runs.
+            if ($HasLocalBin) {
+                $installTarget = $script:InstallScript
+            } else {
+                $quickDir = Join-Path $TestRoot 'quick'
+                New-Item -ItemType Directory -Force -Path $quickDir | Out-Null
+                $installTarget = Join-Path $quickDir 'install.ps1'
+                Copy-Item $script:InstallScript $installTarget
+            }
+
+            # Build a wrapper script that overrides $PROFILE (global so child scopes see it)
+            # and calls install.ps1 with & so $PSScriptRoot is set to install.ps1's own directory.
+            $profileEsc = $profilePath  -replace "'", "''"
+            $homeEsc    = $testHome     -replace "'", "''"
+            $targetEsc  = $installTarget -replace "'", "''"
+
+            $wrapperLines = [System.Collections.Generic.List[string]]::new()
+            if ($MockWebRequest) {
+                $wrapperLines.Add(@'
+function global:Invoke-WebRequest {
+    param([string]$Uri, [string]$OutFile)
+    '# mock downloaded' | Set-Content $OutFile
+}
+'@)
+            }
+            $wrapperLines.Add("`$global:PROFILE = '$profileEsc'")
+            $wrapperLines.Add("`$env:USERPROFILE = '$homeEsc'")
+            $wrapperLines.Add("& '$targetEsc'")
+
+            $wrapperPath = Join-Path $TestRoot 'wrapper.ps1'
+            ($wrapperLines -join "`n") | Set-Content $wrapperPath -NoNewline
+
+            $pwshCommand = (Get-Command pwsh).Source
+            $process = Start-Process -FilePath $pwshCommand `
+                -ArgumentList @('-NoProfile', '-File', $wrapperPath) `
+                -RedirectStandardOutput $stdoutFile `
+                -RedirectStandardError  $stderrFile `
+                -NoNewWindow `
+                -PassThru `
+                -Wait
+
+            $stdout = ((Get-Content $stdoutFile) -join "`n").TrimEnd()
+            $stderr = ((Get-Content $stderrFile) -join "`n").TrimEnd()
+
+            [pscustomobject]@{
+                Status     = $process.ExitCode
+                Stdout     = $stdout
+                Stderr     = $stderr
+                InstallDir = Join-Path $testHome 'bin'
+                Profile    = $profilePath
+            }
+        }
+    }
+
+    BeforeEach {
+        $TestRoot = New-TestFixture
+    }
+
+    AfterEach {
+        Remove-TestFixture $TestRoot
+    }
+
+    Context 'clone install' {
+        It 'copies git-cd.ps1 to the install directory' {
+            $result = Invoke-InstallPs1 -TestRoot $TestRoot
+
+            $result.Status | Should -Be 0
+            Test-Path (Join-Path $result.InstallDir 'git-cd.ps1') | Should -Be $true
+        }
+
+        It 'copies git-cd.cmd to the install directory' {
+            $result = Invoke-InstallPs1 -TestRoot $TestRoot
+
+            $result.Status | Should -Be 0
+            Test-Path (Join-Path $result.InstallDir 'git-cd.cmd') | Should -Be $true
+        }
+
+        It 'is idempotent' {
+            Invoke-InstallPs1 -TestRoot $TestRoot | Out-Null
+            $result = Invoke-InstallPs1 -TestRoot $TestRoot
+
+            $result.Status | Should -Be 0
+            Test-Path (Join-Path $result.InstallDir 'git-cd.ps1') | Should -Be $true
+        }
+    }
+
+    Context 'quick install' {
+        It 'downloads git-cd.ps1 when local bin is not available' {
+            $result = Invoke-InstallPs1 -TestRoot $TestRoot -HasLocalBin $false -MockWebRequest $true
+
+            $result.Status | Should -Be 0
+            Test-Path (Join-Path $result.InstallDir 'git-cd.ps1') | Should -Be $true
+        }
+
+        It 'downloads git-cd.cmd when local bin is not available' {
+            $result = Invoke-InstallPs1 -TestRoot $TestRoot -HasLocalBin $false -MockWebRequest $true
+
+            $result.Status | Should -Be 0
+            Test-Path (Join-Path $result.InstallDir 'git-cd.cmd') | Should -Be $true
+        }
+    }
+
+    Context 'install directory' {
+        It 'creates the install directory when it does not exist' {
+            $result = Invoke-InstallPs1 -TestRoot $TestRoot
+
+            $result.Status | Should -Be 0
+            Test-Path $result.InstallDir -PathType Container | Should -Be $true
+        }
+    }
+
+    Context 'profile setup' {
+        It 'creates the profile file when it does not exist' {
+            $result = Invoke-InstallPs1 -TestRoot $TestRoot
+
+            $result.Status | Should -Be 0
+            Test-Path $result.Profile | Should -Be $true
+        }
+
+        It 'adds shell function to a fresh profile' {
+            $result = Invoke-InstallPs1 -TestRoot $TestRoot
+
+            $content = Get-Content $result.Profile -Raw
+            $content | Should -Match '# git-cd BEGIN'
+            $content | Should -Match 'function git'
+            $content | Should -Match '# git-cd END'
+        }
+
+        It 'installed shell function uses @(if...) array wrapping to avoid char-by-char splatting' {
+            $result = Invoke-InstallPs1 -TestRoot $TestRoot
+
+            $content = Get-Content $result.Profile -Raw
+            $content | Should -Match ([regex]::Escape('@(if ($args.Length -gt 1)'))
+        }
+
+        It 'replaces old shell function in profile when it already exists' {
+            $oldFunction = @'
+# git-cd BEGIN
+function git {
+    if ($args[0] -eq 'cd') {
+        $rest = if ($args.Length -gt 1) { $args[1..($args.Length - 1)] } else { @() }
+        $dir = & git-cd @rest
+        if ($dir) { Set-Location $dir }
+    } else {
+        & (Get-Command git -CommandType Application) @args
+    }
+}
+# git-cd END
+'@
+            $result = Invoke-InstallPs1 -TestRoot $TestRoot -ExistingProfileContent $oldFunction
+
+            $result.Status | Should -Be 0
+            $content = Get-Content $result.Profile -Raw
+            $content | Should -Match ([regex]::Escape('@(if ($args.Length -gt 1)'))
+            $content | Should -Not -Match ([regex]::Escape('$rest = if ($args.Length -gt 1) { $args['))
+        }
+
+        It 'does not duplicate shell function when run twice' {
+            Invoke-InstallPs1 -TestRoot $TestRoot | Out-Null
+            Invoke-InstallPs1 -TestRoot $TestRoot | Out-Null
+
+            $content = Get-Content (Join-Path $TestRoot 'ps-profile.ps1') -Raw
+            ([regex]::Matches($content, '# git-cd BEGIN')).Count | Should -Be 1
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add \`bin/git-cd.ps1\`: PowerShell version of the main script
- Add \`bin/git-cd.cmd\`: CMD launcher shim for Windows (delegates to \`git-cd.ps1\` via \`pwsh\`)
- Add \`install.ps1\`: Windows installer that places scripts in \`~\bin\`, adds to PATH, and injects shell function into \`$PROFILE\`
- Add \`README-WIN.md\`: Windows-specific docs with usage, install, and uninstall instructions
- Update \`CONTRIBUTING.md\`: add Pester setup, run instructions, and cross-platform test parity table
- Update \`release.yml\`: include \`git-cd.ps1\`, \`git-cd.cmd\`, and \`install.ps1\` as release assets
- Update \`test.yml\`: add \`pester\` CI job that runs \`git-cd.Tests.ps1\` on \`windows-latest\`
- Add \`.vscode/settings.json\`: suppress cSpell warnings for Windows-specific terms

## Test plan

- [x] Run \`install.ps1\` on Windows and verify \`git cd\` works in PowerShell
- [x] Verify fzf fallback (numbered list) works without fzf installed
- [x] Verify \`--cache\`, \`--depth\`, \`--submodules\` options work
- [x] Confirm Pester CI job passes on \`windows-latest\` in GitHub Actions