### PR TITLE
Add install date comment and update shell function on reinstall

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -12,6 +12,7 @@ $HasLocalScripts = $ScriptDir -and
     (Test-Path (Join-Path $ScriptDir "bin\git-cd.ps1")) -and
     (Test-Path (Join-Path $ScriptDir "bin\git-cd.cmd"))
 
+$InstallDate = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
 $ShellFunction = @'
 
 # git-cd BEGIN
@@ -26,6 +27,7 @@ function git {
 }
 # git-cd END
 '@
+$ShellFunction = $ShellFunction -replace '# git-cd BEGIN', "# git-cd BEGIN`n# Installed: $InstallDate"
 
 # Place git-cd.ps1
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
@@ -71,7 +73,7 @@ if ($profileContent -notlike "*# git-cd BEGIN*") {
 }
 
 Write-Host ""
-Write-Host "✅ Done!"
+Write-Host "[ Done! ]"
 Write-Host "Open a new terminal to start using 'git cd'."
 Write-Host ""
 Write-Host "Tip: install fzf for a better experience:"

--- a/install.sh
+++ b/install.sh
@@ -5,8 +5,11 @@ set -euo pipefail
 INSTALL_DIR="${HOME}/.local/bin"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-SHELL_FUNCTION='
-# git-cd: navigate to git repositories interactively
+INSTALL_DATE="$(date '+%Y-%m-%d %H:%M:%S')"
+SHELL_FUNCTION_HEAD="
+# git-cd BEGIN
+# Installed: $INSTALL_DATE"
+SHELL_FUNCTION_BODY='
 git() {
   if [ "${1:-}" = "cd" ]; then
     shift
@@ -15,7 +18,9 @@ git() {
   else
     command git "$@"
   fi
-}'
+}
+# git-cd END'
+SHELL_FUNCTION="${SHELL_FUNCTION_HEAD}${SHELL_FUNCTION_BODY}"
 
 if [ -f "$SCRIPT_DIR/bin/git-cd" ]; then
   # Clone install: create a symlink so `git pull` automatically reflects updates
@@ -44,9 +49,17 @@ if ! grep -q '\.local/bin' "$RC_FILE" 2>/dev/null; then
   echo "Added $INSTALL_DIR to PATH in $RC_FILE"
 fi
 
-# Append shell function if not already present
-if grep -q "# git-cd" "$RC_FILE" 2>/dev/null; then
-  echo "Shell function already exists in $RC_FILE"
+# Append or update shell function
+if grep -q "# git-cd BEGIN" "$RC_FILE" 2>/dev/null; then
+  _FUNC_FILE="$(mktemp)"
+  printf '%s' "$SHELL_FUNCTION" > "$_FUNC_FILE"
+  FUNC_FILE="$_FUNC_FILE" perl -i -0pe '
+    my $r = do { local $/; open(my $fh, "<", $ENV{FUNC_FILE}) or die; <$fh> };
+    $r =~ s/^\s*//;
+    s/# git-cd BEGIN.*?# git-cd END/$r/s;
+  ' "$RC_FILE"
+  rm -f "$_FUNC_FILE"
+  echo "Updated shell function in $RC_FILE"
 else
   printf '%s\n' "$SHELL_FUNCTION" >> "$RC_FILE"
   echo "Added shell function to $RC_FILE"

--- a/tests/install.Tests.ps1
+++ b/tests/install.Tests.ps1
@@ -162,6 +162,7 @@ function global:Invoke-WebRequest {
 
             $content = Get-Content $result.Profile -Raw
             $content | Should -Match '# git-cd BEGIN'
+            $content | Should -Match '# Installed:'
             $content | Should -Match 'function git'
             $content | Should -Match '# git-cd END'
         }
@@ -191,6 +192,7 @@ function git {
 
             $result.Status | Should -Be 0
             $content = Get-Content $result.Profile -Raw
+            $content | Should -Match '# Installed:'
             $content | Should -Match ([regex]::Escape('@(if ($args.Length -gt 1)'))
             $content | Should -Not -Match ([regex]::Escape('$rest = if ($args.Length -gt 1) { $args['))
         }
@@ -201,6 +203,7 @@ function git {
 
             $content = Get-Content (Join-Path $TestRoot 'ps-profile.ps1') -Raw
             ([regex]::Matches($content, '# git-cd BEGIN')).Count | Should -Be 1
+            ([regex]::Matches($content, '# Installed:')).Count | Should -Be 1
         }
     }
 }

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -100,20 +100,29 @@ run_quick_install() {
 
 # describe: shell function setup
 
-@test "adds shell function to rc file" {
+@test "adds shell function with BEGIN/END markers to rc file" {
   run_install
 
   [ "$status" -eq 0 ]
-  grep -q 'git-cd' "$FAKE_HOME/.bashrc"
+  grep -q '# git-cd BEGIN' "$FAKE_HOME/.bashrc"
+  grep -q '# git-cd END' "$FAKE_HOME/.bashrc"
 }
 
-@test "does not add shell function when already present" {
-  printf '# git-cd: navigate to git repositories interactively\n' > "$FAKE_HOME/.bashrc"
+@test "adds Installed date comment to rc file" {
+  run_install
+
+  [ "$status" -eq 0 ]
+  grep -q '# Installed:' "$FAKE_HOME/.bashrc"
+}
+
+@test "updates shell function when already present" {
+  printf '# git-cd BEGIN\n# Installed: 2000-01-01 00:00:00\ngit() { : ; }\n# git-cd END\n' > "$FAKE_HOME/.bashrc"
 
   run_install
 
   [ "$status" -eq 0 ]
-  [ "$(grep -c '# git-cd' "$FAKE_HOME/.bashrc")" -eq 1 ]
+  [ "$(grep -c '# git-cd BEGIN' "$FAKE_HOME/.bashrc")" -eq 1 ]
+  ! grep -q '# Installed: 2000-01-01 00:00:00' "$FAKE_HOME/.bashrc"
 }
 
 @test "added shell function forwards args to git-cd" {
@@ -133,6 +142,7 @@ run_quick_install() {
 }
 
 @test "writes to .zshrc when SHELL is zsh" {
+  unset ZDOTDIR
   run env HOME="$FAKE_HOME" SHELL="/bin/zsh" PATH="$MOCK_BIN:$PATH" bash "$INSTALL_SH"
 
   [ "$status" -eq 0 ]


### PR DESCRIPTION
- Embed `# Installed: <date>` in the shell function block on install/update
- Replace existing git-cd BEGIN...END block instead of skipping when already present
- Replace ✅ with ASCII "[ Done! ]" for PowerShell 5.x compatibility
- Update tests to assert BEGIN/END markers, Installed comment, and update behavior